### PR TITLE
[BUG] unable to save shapes on max edges

### DIFF
--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -135,8 +135,9 @@ class Canvas(QWidget):
                     # Clip the coordinates to 0 or max,
                     # if they are outside the range [0, max]
                     size = self.pixmap.size()
-                    clipped_x = min(max(0, pos.x()), size.width())
-                    clipped_y = min(max(0, pos.y()), size.height())
+                    # added leeway of 0.000001 due to bug on floating numbers
+                    clipped_x = min(max(0, pos.x()), size.width() - 0.000001)
+                    clipped_y = min(max(0, pos.y()), size.height() - 0.000001)
                     pos = QPointF(clipped_x, clipped_y)
                 elif len(self.current) > 1 and self.closeEnough(pos, self.current[0]):
                     # Attract line to starting point and colorise to alert the
@@ -450,8 +451,6 @@ class Canvas(QWidget):
     def rotateVertex(self, pos):
         index, shape = self.hVertex, self.hShape
         point = shape[index]
-        if self.outOfPixmap(pos):
-            pos = self.intersectionPoint(point, pos)
 
         if not self.drawSquare:
             angle_target =   math.atan2(pos.y()  -shape.origin[1], pos.x()  -shape.origin[0])
@@ -461,8 +460,6 @@ class Canvas(QWidget):
     def rotateVertexAll(self, pos):
         index, shape = self.hVertex, self.hShape
         point = shape[index]
-        if self.outOfPixmap(pos):
-            pos = self.intersectionPoint(point, pos)
 
         if not self.drawSquare:
             angle_target =   math.atan2(pos.y()  -shape.origin[1], pos.x()  -shape.origin[0])
@@ -620,7 +617,7 @@ class Canvas(QWidget):
 
     def outOfPixmap(self, p):
         w, h = self.pixmap.width(), self.pixmap.height()
-        return not (0 <= p.x() <= w and 0 <= p.y() <= h)
+        return not (0 <= p.x() < w and 0 <= p.y() < h)
 
     def finalise(self):
         assert self.current

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -507,7 +507,7 @@ class Canvas(QWidget):
         dp = pos - self.prevPoint
         if dp:
             for s in self.shapes:
-                s.moveBy(dp)
+                s.moveByWithinCanvas(dp, self.pixmap.width(), self.pixmap.height())
             self.prevPoint = pos
             return True
         return False
@@ -711,7 +711,7 @@ class Canvas(QWidget):
 
         if move_all:
             for shape in self.shapes:
-                shape.moveBy(movement)
+                shape.moveByWithinCanvas(movement, self.pixmap.width(), self.pixmap.height())
         else:
             self.selectedShape.moveBy(movement)
 

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -475,8 +475,8 @@ class Canvas(QWidget):
             pos -= QPointF(min(0, o1.x()), min(0, o1.y()))
         o2 = pos + self.offsets[1]
         if self.outOfPixmap(o2):
-            pos += QPointF(min(0, self.pixmap.width() - o2.x()),
-                           min(0, self.pixmap.height() - o2.y()))
+            pos += QPointF(min(0, self.pixmap.width() - 0.000001 - o2.x()),
+                           min(0, self.pixmap.height() - 0.000001 - o2.y()))
         # The next line tracks the new position of the cursor
         # relative to the shape, but also results in making it
         # a bit "shaky" when nearing the border and allows it to
@@ -497,8 +497,8 @@ class Canvas(QWidget):
             pos -= QPointF(min(0, o1.x()), min(0, o1.y()))
         o2 = pos + self.offsets[1]
         if self.outOfPixmap(o2):
-            pos += QPointF(min(0, self.pixmap.width() - o2.x()),
-                           min(0, self.pixmap.height() - o2.y()))
+            pos += QPointF(min(0, self.pixmap.width() - 0.000001 - o2.x()),
+                           min(0, self.pixmap.height() - 0.000001 - o2.y()))
         # The next line tracks the new position of the cursor
         # relative to the shape, but also results in making it
         # a bit "shaky" when nearing the border and allows it to

--- a/libs/shape.py
+++ b/libs/shape.py
@@ -195,6 +195,16 @@ class Shape(object):
         self.points = [p + offset for p in self.points]
         self.updateOBBInfo()
 
+    def moveByWithinCanvas(self, offset, pixmap_width, pixmap_height):
+        toMove = True
+        for p in self.points:
+            targetPoint = p + offset
+            if targetPoint.x() > pixmap_width or targetPoint.y() > pixmap_height or targetPoint.x() < 0 or targetPoint.y() < 0:
+                toMove = False
+                break
+        if toMove:
+            self.moveBy(offset)
+
     def moveVertexBy(self, i, offset):
         self.points[i] = self.points[i] + offset
         self.updateOBBInfo()


### PR DESCRIPTION
Added some leeway so it does not reach the exact max value on the x or y coordinates.

Suspect error was due to floating point numbers actually exceeding the canvas

tested:
1) drew a horizontal OBB that reaches the btm or right side of canvas
2) drew a OBB within canvas and moved its vertex to the btm and right side of canvas
3) drew a obb within canvas and rotate its vertex such that a corner of the bb would be touching the btm or right side of canvas

Those are the scenarios that had trouble before and they were solved. please test it and see if you could think of other scenarios